### PR TITLE
Enable logging Craft errors via an optional log route

### DIFF
--- a/papertrail/PapertrailPlugin.php
+++ b/papertrail/PapertrailPlugin.php
@@ -68,7 +68,7 @@ class PapertrailPlugin extends BasePlugin
 	 */
 	public function getVersion()
 	{
-		return '1.0.0';
+		return '1.1.0';
 	}
 
 
@@ -112,6 +112,20 @@ class PapertrailPlugin extends BasePlugin
 	public function onBeforeInstall()
 	{
 		return true;
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function init()
+	{
+		if (craft()->config->get('enableLogRoute', 'papertrail') === true) {
+			// Help the Yii autoloader to find the file
+			\Yii::$classMap['Craft\PapertrailRoute'] = realpath(__DIR__) . '/logroutes/PapertrailRoute.php';
+
+			// Add PapertrailRoute logger class
+			craft()->log->addRoute('Craft\PapertrailRoute');
+		}
 	}
 
 

--- a/papertrail/config.php
+++ b/papertrail/config.php
@@ -14,10 +14,11 @@
 
 return array(
 
-	'papertrailHost' => false,
-	'papertrailPort' => false,
-
+	'papertrailHost' => false, // e.g. logN.papertrailapp.com
+	'papertrailPort' => false, // e.g. 123456
 	'appendLevel' => false,
 	'prependLevel' => true,
+	'enableLogRoute' => false, // enable automatic logging of Craft errors to papertrail, not just template errors
+	'maxSeverity' => 7, // Don't log errors with a severity higher than this
 
 );

--- a/papertrail/helpers/PapertrailHelper.php
+++ b/papertrail/helpers/PapertrailHelper.php
@@ -45,6 +45,11 @@ class PapertrailHelper
 		$system = !empty($system) ? $system : CRAFT_ENVIRONMENT;
 		$severity = isset(self::$_severityCodes[$level]) ? self::$_severityCodes[$level] : self::$_severityCodes['informational'];
 
+		if (self::ignore_severity($severity))
+		{
+			return;
+		}
+
 		if (!is_string($msg))
 		{
 			$msg = print_r($msg, true);
@@ -114,6 +119,13 @@ class PapertrailHelper
 		return $sent;
 
 	}
-
-
+	/**
+	 * @param  int $severity
+	 * @return boolean
+	 */
+	private function ignore_severity($severity)
+	{
+		$maxSeverity = craft()->config->get('maxSeverity', 'papertrail');
+		return (intval($severity) >= intval($maxSeverity));
+	}
 }

--- a/papertrail/logroutes/PapertrailRoute.php
+++ b/papertrail/logroutes/PapertrailRoute.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Craft;
+
+ /**
+ * Papertrail: PapertrailRoute
+ *
+ * @author    Tom Davies <tom@madebykind.com>
+ * @copyright Copyright (c) 2016, Michael Rog, Tom Davies
+ * @see       http://topshelfcraft.com
+ * @package   craft.plugins.papertrail
+ * @since     1.1
+ */
+class PapertrailRoute extends \CLogRoute
+{
+
+	/**
+	 * @param array $logs
+	 */
+	public function processLogs($logs)
+	{
+
+		foreach ($logs as $log) {
+
+			$msg 	= $log[0];
+			$level 	= isset($log[1]) ? $log[1] : '';
+			$type   = isset($log[2]) ? $log[2] : '';
+			$name   = isset($log[5]) ? $log[5] : '';
+
+			PapertrailHelper::log("[$type.$name] $msg", $level);
+		}
+	}
+}


### PR DESCRIPTION
Howdy @michaelrog. This PR:

- Adds an optional (disabled by default) log route for sending all craft logs to Papertrail
- Adds a `maxSeverity` setting for reducing log noise on a per-environment basis